### PR TITLE
- Using Material snackbar in replacement of kendo-angular-notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@progress/kendo-angular-menu": "^11.0.0",
     "@progress/kendo-angular-messages": "^1.42.0",
     "@progress/kendo-angular-navigation": "^11.0.0",
-    "@progress/kendo-angular-notification": "^11.0.0",
     "@progress/kendo-angular-pdf-export": "^11.0.0",
     "@progress/kendo-angular-popup": "^11.0.0",
     "@progress/kendo-angular-ripple": "^11.0.0",

--- a/src/app/shared/components/components.module.ts
+++ b/src/app/shared/components/components.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterModule } from '@angular/router';
 import { ButtonsModule } from '@progress/kendo-angular-buttons';
 import { DatePickerModule } from '@progress/kendo-angular-dateinputs';
@@ -12,7 +13,6 @@ import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 import { InputsModule } from '@progress/kendo-angular-inputs';
 import { LabelModule } from '@progress/kendo-angular-label';
 import { BreadCrumbModule } from '@progress/kendo-angular-navigation';
-import { NotificationModule } from '@progress/kendo-angular-notification';
 import { RippleModule } from '@progress/kendo-angular-ripple';
 import { TooltipsModule } from '@progress/kendo-angular-tooltip';
 import { DirectivesModule } from '../directives/directives.module';
@@ -108,11 +108,11 @@ import { YesNoStatusComponent } from './yes-no-status/yes-no-status.component';
     DialogModule,
     DropDownsModule,
     DatePickerModule,
-    NotificationModule,
     IconsModule,
     PipesModule,
     DirectivesModule,
     RouterModule,
+    MatSnackBarModule,
   ],
   exports: [
     CommonModule,

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -6,6 +6,8 @@
   padding: $padding-medium;
   border-radius: $radius-small;
   border-left: 4px solid $color-primary-base;
+  background-color: $color-white;
+  color: $color-neutral;
 }
 
 .notification-type-error {
@@ -17,11 +19,16 @@ p {
   padding: 0 $padding-small;
 }
 
-::ng-deep .k-notification-group {
+::ng-deep .mat-mdc-snack-bar-container {
   margin-block: $padding-large;
   margin-inline: $padding-large;
 
-  .k-notification {
+  .mdc-snackbar__surface {
+    padding: 0;
+    min-width: 0;
+  }
+
+  .mat-mdc-snack-bar-label {
     padding: 0;
   }
 }

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Actions, ofType } from '@ngrx/effects';
-import { NotificationService as KendoNotificationService } from '@progress/kendo-angular-notification';
 import { Subscription } from 'rxjs';
 import { ITSystemUsageActions } from 'src/app/store/it-system-usage/actions';
 import { UserActions } from 'src/app/store/user-store/actions';
@@ -11,7 +11,7 @@ import { NotificationType } from '../enums/notification-type';
 export class NotificationService implements OnDestroy {
   public subscriptions = new Subscription();
 
-  constructor(private actions$: Actions, private notificationService: KendoNotificationService) {}
+  constructor(private actions$: Actions, private readonly snackBar: MatSnackBar) {}
 
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
@@ -53,19 +53,19 @@ export class NotificationService implements OnDestroy {
   }
 
   public show(text: string, type: NotificationType) {
-    const notificationRef = this.notificationService.show({
-      content: NotificationComponent,
-      hideAfter: 3500,
-      position: { horizontal: 'right', vertical: 'bottom' },
-      animation: { type: 'fade', duration: 500 },
+    //TODO: Unlike kendo, this one updates existing snackbar in stead of stacking them
+    const notificationRef = this.snackBar.openFromComponent(NotificationComponent, {
+      duration: 3500,
+      horizontalPosition: 'right',
+      verticalPosition: 'bottom',
     });
 
-    const notificationComponent = notificationRef.content?.instance as NotificationComponent;
+    const notificationComponent = notificationRef.instance as NotificationComponent;
 
     if (notificationComponent) {
       notificationComponent.text = text;
       notificationComponent.type = type;
-      notificationComponent.hide.subscribe(() => notificationRef.hide());
+      notificationComponent.hide.subscribe(() => notificationRef.dismiss());
     }
   }
 

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -57,10 +57,7 @@ $kendo-tooltip-padding-x: 12px;
 
 // Import Kendo UI component styles
 
-// @import "@progress/kendo-theme-material/dist/all.scss";
-
 @import "@progress/kendo-theme-material/scss/utils/_index.scss";
-
 @import "@progress/kendo-theme-material/scss/button/_index.scss";
 @import "@progress/kendo-theme-material/scss/grid/_index.scss";
 @import "@progress/kendo-theme-material/scss/badge/_index.scss";
@@ -68,7 +65,6 @@ $kendo-tooltip-padding-x: 12px;
 @import "@progress/kendo-theme-material/scss/appbar/_index.scss";
 @import "@progress/kendo-theme-material/scss/breadcrumb/_index.scss";
 @import "@progress/kendo-theme-material/scss/ripple/_index.scss";
-@import "@progress/kendo-theme-material/scss/notification/_index.scss";
 @import "@progress/kendo-theme-material/scss/dialog/_index.scss";
 @import "@progress/kendo-theme-material/scss/datepicker/_index.scss";
 @import "@progress/kendo-theme-material/scss/loader/_index.scss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,14 +2768,6 @@
     "@progress/kendo-angular-schematics" "11.0.0"
     tslib "^2.3.1"
 
-"@progress/kendo-angular-notification@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@progress/kendo-angular-notification/-/kendo-angular-notification-11.0.0.tgz#47c7dfeb347df51ae039106938dbc5e52ceea76b"
-  integrity sha512-D+Mh2iSDix3H2fWUhI+4VAs4aKrlHNhuVGRT7dTJgFqMU+12FWnXJNlX5uwcI8wut3Q03dAdWPB9ctGT4nPAFw==
-  dependencies:
-    "@progress/kendo-angular-schematics" "11.0.0"
-    tslib "^2.3.1"
-
 "@progress/kendo-angular-pdf-export@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@progress/kendo-angular-pdf-export/-/kendo-angular-pdf-export-11.0.0.tgz#ef4da6494ffd1f1dfdab44af62136f02cbb4b44e"


### PR DESCRIPTION
- Missing: Ability to show multiple active toast messages (not supported out of the box by angular material ui)