### PR TITLE
Bugfix/kitosudv 4551

### DIFF
--- a/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-contracts/it-system-usage-details-contracts.component.ts
+++ b/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-contracts/it-system-usage-details-contracts.component.ts
@@ -27,9 +27,9 @@ export class ITSystemUsageDetailsContractsComponent extends BaseComponent implem
   public readonly mainContract$ = this.store.select(selectItSystemUsageMainContract);
   public readonly mainContractIsValid$ = this.store.select(selectItSystemUsageValidAccordingToMainContract);
   public readonly availableContractsForSelection$ = this.contractsStore.associatedContracts$;
-  public availableContractTypesDictionary$ = this.store.select(
-    selectRegularOptionTypesDictionary('it-contract_contract-type')
-  );
+  public availableContractTypesDictionary$ = this.store
+    .select(selectRegularOptionTypesDictionary('it-contract_contract-type'))
+    .pipe(filterNullish());
   public readonly isLoading$ = this.contractsStore.associatedContractsIsLoading$;
   public readonly contractRows$ = this.contractsStore.contractRows$;
   public readonly anyContracts$ = this.contractRows$.pipe(matchNonEmptyArray());

--- a/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-frontpage-catalog/it-system-usage-details-frontpage-catalog.component.ts
+++ b/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-frontpage-catalog/it-system-usage-details-frontpage-catalog.component.ts
@@ -53,7 +53,9 @@ export class ITSystemUsageDetailsFrontpageCatalogComponent extends BaseComponent
   });
 
   public readonly kle$ = this.store.select(selectItSystemKleWithDetails);
-  public readonly businessTypes$ = this.store.select(selectRegularOptionTypes('it-system_business-type'));
+  public readonly businessTypes$ = this.store
+    .select(selectRegularOptionTypes('it-system_business-type'))
+    .pipe(filterNullish());
   public readonly itSystemIsActive$ = this.store.select(selectItSystemIsActive);
   public readonly itSystemCatalogItemUuid$ = this.store.select(selectItSystemUsageSystemContextUuid);
 

--- a/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-frontpage-information/it-system-usage-details-frontpage-information.component.ts
+++ b/src/app/modules/it-systems/it-system-usages/it-system-usage-details/it-system-usage-details-frontpage-information/it-system-usage-details-frontpage-information.component.ts
@@ -65,9 +65,9 @@ export class ITSystemUsageDetailsFrontpageInformationComponent extends BaseCompo
   public readonly lifeCycleStatusOptions = lifeCycleStatusOptions;
 
   public readonly itSystemUsageValid$ = this.store.select(selectItSystemUsageValid);
-  public readonly dataClassificationTypes$ = this.store.select(
-    selectRegularOptionTypes('it-system_usage-data-classification-type')
-  );
+  public readonly dataClassificationTypes$ = this.store
+    .select(selectRegularOptionTypes('it-system_usage-data-classification-type'))
+    .pipe(filterNullish());
   public readonly invalidReason$ = this.store.select(selectItSystemUsageGeneral).pipe(
     map((general) => {
       if (general?.validity.valid) return undefined;

--- a/src/app/modules/it-systems/shared/it-system-interfaces-table/it-system-interfaces-table.component.ts
+++ b/src/app/modules/it-systems/shared/it-system-interfaces-table/it-system-interfaces-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { BaseComponent } from 'src/app/shared/base/base.component';
+import { filterNullish } from 'src/app/shared/pipes/filter-nullish';
 import { invertBooleanValue } from 'src/app/shared/pipes/invert-boolean-value';
 import { matchEmptyArray } from 'src/app/shared/pipes/match-empty-array';
 import { RegularOptionTypeActions } from 'src/app/store/regular-option-type-store/actions';
@@ -17,9 +18,9 @@ export class ItSystemInterfacesTableComponent extends BaseComponent implements O
   public readonly isLoading$ = this.interfaceStore.itInterfacesIsLoading$;
   public readonly itInterfaces$ = this.interfaceStore.itInterfaces$;
   public readonly anyInterfaces$ = this.itInterfaces$.pipe(matchEmptyArray(), invertBooleanValue());
-  public readonly availableInterfaceTypesDictionary$ = this.store.select(
-    selectRegularOptionTypesDictionary('it-interface_interface-type')
-  );
+  public readonly availableInterfaceTypesDictionary$ = this.store
+    .select(selectRegularOptionTypesDictionary('it-interface_interface-type'))
+    .pipe(filterNullish());
 
   @Input() public systemUuid = '';
 

--- a/src/app/store/regular-option-type-store/reducer.ts
+++ b/src/app/store/regular-option-type-store/reducer.ts
@@ -16,10 +16,10 @@ const createInitialOptionState = () =>
 
 function createEmptyState(): RegularOptionTypeState {
   return {
-    'it-contract_contract-type': createInitialOptionState(),
-    'it-interface_interface-type': createInitialOptionState(),
-    'it-system_business-type': createInitialOptionState(),
-    'it-system_usage-data-classification-type': createInitialOptionState(),
+    'it-contract_contract-type': null,
+    'it-interface_interface-type': null,
+    'it-system_business-type': null,
+    'it-system_usage-data-classification-type': null,
   };
 }
 
@@ -30,10 +30,10 @@ export const regularOptionTypeFeature = createFeature({
   reducer: createReducer(
     regularOptionTypeInitialState,
     on(RegularOptionTypeActions.getOptionsSuccess, (state, { optionType, options }): RegularOptionTypeState => {
-      const nextState = cloneDeep(state);
+      const nextState = state ? cloneDeep(state) : createEmptyState();
 
       //Update the changed state
-      const currentOptionState = nextState[optionType];
+      const currentOptionState = nextState[optionType] ?? createInitialOptionState();
       nextState[optionType] = {
         ...regularOptionTypeAdapter.setAll(options, currentOptionState),
         cacheTime: new Date().getTime(),

--- a/src/app/store/regular-option-type-store/selectors.ts
+++ b/src/app/store/regular-option-type-store/selectors.ts
@@ -11,17 +11,21 @@ export const selectStateByOptionType = memoize((optionType: RegularOptionTypes) 
 );
 
 export const selectRegularOptionTypes = memoize((optionType: RegularOptionTypes) =>
-  createSelector(selectStateByOptionType(optionType), regularOptionTypeAdapter.getSelectors().selectAll)
+  createSelector(selectStateByOptionType(optionType), (optionState) =>
+    optionState ? regularOptionTypeAdapter.getSelectors().selectAll(optionState) : null
+  )
 );
 
 export const selectRegularOptionTypesDictionary = memoize((optionType: RegularOptionTypes) =>
-  createSelector(selectStateByOptionType(optionType), regularOptionTypeAdapter.getSelectors().selectEntities)
+  createSelector(selectStateByOptionType(optionType), (optionState) =>
+    optionState ? regularOptionTypeAdapter.getSelectors().selectEntities(optionState) : null
+  )
 );
 
 export const selectHasValidCache = memoize((optionType: RegularOptionTypes) =>
   createSelector(
     selectRegularOptionTypeState,
     () => new Date(),
-    (state, time) => hasValidCache(state[optionType].cacheTime, time)
+    (state, time) => hasValidCache(state[optionType]?.cacheTime, time)
   )
 );

--- a/src/app/store/regular-option-type-store/state.ts
+++ b/src/app/store/regular-option-type-store/state.ts
@@ -6,4 +6,4 @@ export interface RegularOptionTypeStateItem extends EntityState<APIRegularOption
   cacheTime: number | undefined;
 }
 
-export type RegularOptionTypeState = Record<RegularOptionTypes, RegularOptionTypeStateItem>;
+export type RegularOptionTypeState = Record<RegularOptionTypes, RegularOptionTypeStateItem | null>;


### PR DESCRIPTION
Change initial state of options in the store to be null, so that initial unloaded state is not used in views (or at least they can chose not to use it using filtering)
This allows us to postpone rendering of outputs from the stream until they have actually been loaded