### PR TITLE
bug: fix drag-n-drop container overflow scrollbar during drag preview

### DIFF
--- a/src/app/shared/components/drag-and-drop-tree/drag-and-drop-tree.component.scss
+++ b/src/app/shared/components/drag-and-drop-tree/drag-and-drop-tree.component.scss
@@ -10,7 +10,7 @@
 
   background: #fff;
   opacity: 0.3;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .drop-inside {

--- a/src/app/shared/components/drag-and-drop-tree/drag-and-drop-tree.component.scss
+++ b/src/app/shared/components/drag-and-drop-tree/drag-and-drop-tree.component.scss
@@ -10,6 +10,7 @@
 
   background: #fff;
   opacity: 0.3;
+  overflow: hidden;
 }
 
 .drop-inside {


### PR DESCRIPTION
This PR fixed a bug where a scrollbar would appear inside drag-and-drop-tree nodes' preview container.

Before
![image-20240909-074610 (1)](https://github.com/user-attachments/assets/1c2cfe0c-7213-4cb2-8a3b-5a0330b66f75)

Now
![image](https://github.com/user-attachments/assets/4f164d54-5140-4dde-ba07-325cc061e528)
![image](https://github.com/user-attachments/assets/0fd09635-79c7-4808-ba06-ec196ad45496)

### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [ ] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Request review**
      _Tag whomever you wish to review your code_
