### PR TITLE
bug: Add option to define boolean value display type in GridColumn

### DIFF
--- a/src/app/modules/it-systems/it-system-usages/it-system-usages.component.ts
+++ b/src/app/modules/it-systems/it-system-usages/it-system-usages.component.ts
@@ -5,6 +5,7 @@ import { Store } from '@ngrx/store';
 import { CellClickEvent } from '@progress/kendo-angular-grid';
 import { combineLatestWith, first } from 'rxjs';
 import { BaseOverviewComponent } from 'src/app/shared/base/base-overview.component';
+import { BooleanValueDisplayType } from 'src/app/shared/components/status-chip/status-chip.component';
 import { getColumnsToShow } from 'src/app/shared/helpers/grid-config-helper';
 import { GridColumn } from 'src/app/shared/models/grid-column.model';
 import { GridState } from 'src/app/shared/models/grid-state.model';
@@ -353,6 +354,7 @@ export class ITSystemUsagesComponent extends BaseOverviewComponent implements On
       style: 'chip',
       hidden: false,
       persistId: 'Registertype',
+      booleanValueDisplay: BooleanValueDisplayType.YesNo,
     },
     {
       field: 'ActiveArchivePeriodEndDate',

--- a/src/app/shared/components/grid/grid.component.html
+++ b/src/app/shared/components/grid/grid.component.html
@@ -127,6 +127,7 @@
           <app-status-chip
             [type]="column.entityType"
             [value]="searchProperty(dataItem, column.field)"
+            [valueDisplayType]="column.booleanValueDisplay"
           ></app-status-chip>
         </div>
       </ng-template>

--- a/src/app/shared/components/status-chip/status-chip.component.ts
+++ b/src/app/shared/components/status-chip/status-chip.component.ts
@@ -2,6 +2,14 @@ import { Component, Input, OnInit } from '@angular/core';
 import { RegistrationEntityTypes } from '../../models/registrations/registration-entity-categories.model';
 import { EntityStatusTextsService } from '../../services/entity-status-texts.service';
 
+export enum BooleanValueDisplayType {
+  TrueFalse = 'true-false',
+  YesNo = 'yes-no',
+  ActiveInactive = 'active-inactive',
+  ValidInvalid = 'valid-invalid',
+  AvailableNotAvailable = 'available-not-available',
+}
+
 @Component({
   selector: 'app-status-chip',
   templateUrl: 'status-chip.component.html',
@@ -12,6 +20,7 @@ export class StatusChipComponent implements OnInit {
   @Input() public value?: boolean | null = undefined;
   @Input() public title?: string | null = '';
   @Input() public reverseValues?: boolean = false;
+  @Input() public valueDisplayType?: BooleanValueDisplayType | null;
 
   public trueString?: string;
   public falseString?: string;
@@ -19,12 +28,47 @@ export class StatusChipComponent implements OnInit {
   constructor(private readonly statusService: EntityStatusTextsService) {}
 
   ngOnInit() {
-    if (this.type) {
-      const texts = this.statusService.map(this.type);
-      this.trueString = texts.trueString;
-      this.falseString = texts.falseString;
+    if (this.valueDisplayType) {
+      this.setTrueFalseStringsFromValueDisplayType(this.valueDisplayType);
+    }
+    else if (this.type) {
+      this.setTrueFalseStringsFromEntityStatusTexts(this.type);
     } else {
       console.error('type not provided');
+    }
+  }
+
+  private setTrueFalseStringsFromEntityStatusTexts(type: RegistrationEntityTypes) {
+    const texts = this.statusService.map(type);
+    this.trueString = texts.trueString;
+    this.falseString = texts.falseString;
+  }
+
+  private setTrueFalseStringsFromValueDisplayType(valueDisplayType: BooleanValueDisplayType) {
+    switch (valueDisplayType) {
+      case BooleanValueDisplayType.TrueFalse:
+        this.trueString = $localize`Sandt`;
+        this.falseString = $localize`Falsk`;
+        break;
+      case BooleanValueDisplayType.YesNo:
+        this.trueString = $localize`Ja`;
+        this.falseString = $localize`Nej`;
+        break;
+      case BooleanValueDisplayType.ActiveInactive:
+        this.trueString = $localize`Aktiv`;
+        this.falseString = $localize`Inaktiv`;
+        break;
+      case BooleanValueDisplayType.ValidInvalid:
+        this.trueString = $localize`Gyldig`;
+        this.falseString = $localize`Ugyldig`;
+        break;
+      case BooleanValueDisplayType.AvailableNotAvailable:
+        this.trueString = $localize`Tilgængelig`;
+        this.falseString = $localize`Ikke tilgængelig`;
+        break;
+      default:
+        console.error('Invalid value display type');
+        break;
     }
   }
 }

--- a/src/app/shared/models/grid-column.model.ts
+++ b/src/app/shared/models/grid-column.model.ts
@@ -1,3 +1,4 @@
+import { BooleanValueDisplayType } from '../components/status-chip/status-chip.component';
 import { RegistrationEntityTypes } from './registrations/registration-entity-categories.model';
 
 export interface GridColumn {
@@ -42,4 +43,5 @@ export interface GridColumn {
   tooltipPositiveText?: string;
   tooltipNegativeText?: string;
   isSticky?: boolean;
+  booleanValueDisplay?: BooleanValueDisplayType; // Defines how boolean values should be displayed. If not set, RegistrationEntityTypes will be used to derive the display type
 }

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -5015,6 +5015,30 @@
         <source>Masseopret</source>
         <target state="new">Masseopret</target>
       </trans-unit>
+      <trans-unit id="5007829064962714817" datatype="html">
+        <source>Sandt</source>
+        <target state="new">Sandt</target>
+      </trans-unit>
+      <trans-unit id="5605050838129145775" datatype="html">
+        <source>Falsk</source>
+        <target state="new">Falsk</target>
+      </trans-unit>
+      <trans-unit id="1932682501978400963" datatype="html">
+        <source>Inaktiv</source>
+        <target state="new">Inaktiv</target>
+      </trans-unit>
+      <trans-unit id="8572497829221531435" datatype="html">
+        <source>Ugyldig</source>
+        <target state="new">Ugyldig</target>
+      </trans-unit>
+      <trans-unit id="12801649558012035" datatype="html">
+        <source>Tilgængelig</source>
+        <target state="new">Tilgængelig</target>
+      </trans-unit>
+      <trans-unit id="2132355553430813586" datatype="html">
+        <source>Ikke tilgængelig</source>
+        <target state="new">Ikke tilgængelig</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -3844,6 +3844,24 @@
       <trans-unit id="5621443521686858170" datatype="html">
         <source>IT kontrakt</source>
       </trans-unit>
+      <trans-unit id="12801649558012035" datatype="html">
+        <source>Tilgængelig</source>
+      </trans-unit>
+      <trans-unit id="1932682501978400963" datatype="html">
+        <source>Inaktiv</source>
+      </trans-unit>
+      <trans-unit id="2132355553430813586" datatype="html">
+        <source>Ikke tilgængelig</source>
+      </trans-unit>
+      <trans-unit id="5007829064962714817" datatype="html">
+        <source>Sandt</source>
+      </trans-unit>
+      <trans-unit id="5605050838129145775" datatype="html">
+        <source>Falsk</source>
+      </trans-unit>
+      <trans-unit id="8572497829221531435" datatype="html">
+        <source>Ugyldig</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This PR fixes the bug where the IsHoldingDocument or "er dokumentbærende" column of the IT system usages grid displayed wrong texts for it's boolean values. The values displayed in the column were "Aktiv"/"Ikke aktiv" instead of "Ja"/"Nej". This is fixed by adding a new option to the GridColumn model that let's users define a boolean value display type, hence the caller/parent of the Grid decides how booleans are displayed per column. If no display type is provided, the chip component will fallback to using the old method of deriving the displayed text from the Entity Type of the component.

Old UI
![image](https://github.com/user-attachments/assets/c108f1fd-6ff7-4cc5-b663-613c9f314aa5)

New UI
![image](https://github.com/user-attachments/assets/565aa129-2d79-4589-aea7-0063f951ac04)
![image](https://github.com/user-attachments/assets/7e600d5a-76dc-4796-85aa-e9ccb3bf3f4b)

### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [x] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Request review**
      _Tag whomever you wish to review your code_
