### PR TITLE
bug: Fix sticky buttons disappearing when column selection changes

### DIFF
--- a/src/app/shared/components/grid/hide-show-dialog/hide-show-dialog.component.ts
+++ b/src/app/shared/components/grid/hide-show-dialog/hide-show-dialog.component.ts
@@ -35,25 +35,34 @@ export class HideShowDialogComponent implements OnInit {
     column.hidden = !column.hidden;
   }
 
+  mergeColumnChanges(): GridColumn[] {
+    return this.columns.map((originalColumn) => {
+      const updatedColumn = this.columnsCopy.find(c => c.field === originalColumn.field);
+      return updatedColumn ? {...originalColumn, hidden: updatedColumn.hidden} : originalColumn;
+    });
+  }
+
   save() {
+    const updatedColumns = this.mergeColumnChanges();
+
     switch (this.entityType) {
       case 'it-system-usage':
-        this.store.dispatch(ITSystemUsageActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(ITSystemUsageActions.updateGridColumns(updatedColumns));
         break;
       case 'it-system':
-        this.store.dispatch(ITSystemActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(ITSystemActions.updateGridColumns(updatedColumns));
         break;
       case 'it-interface':
-        this.store.dispatch(ITInterfaceActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(ITInterfaceActions.updateGridColumns(updatedColumns));
         break;
       case 'data-processing-registration':
-        this.store.dispatch(DataProcessingActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(DataProcessingActions.updateGridColumns(updatedColumns));
         break;
       case 'it-contract':
-        this.store.dispatch(ITContractActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(ITContractActions.updateGridColumns(updatedColumns));
         break;
       case 'organization-user':
-        this.store.dispatch(OrganizationUserActions.updateGridColumns(this.columnsCopy));
+        this.store.dispatch(OrganizationUserActions.updateGridColumns(updatedColumns));
         break;
       default:
         throw `HideShowDialogComponent: ${this.entityType} not implemented`;

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -5067,6 +5067,10 @@
         <source>Ikke tilgængelig</source>
         <target state="new">Ikke tilgængelig</target>
       </trans-unit>
+      <trans-unit id="8007594754054323000" datatype="html">
+        <source>Brugeren har ingen roller</source>
+        <target state="new">Brugeren har ingen roller</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -3883,6 +3883,9 @@
       <trans-unit id="8572497829221531435" datatype="html">
         <source>Ugyldig</source>
       </trans-unit>
+      <trans-unit id="8007594754054323000" datatype="html">
+        <source>Brugeren har ingen roller</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This PR fixes the bug on the organization/users page where the sticky edit/delete user button disappears whenever you change the columns filter. Now the edit/delete column will always be displayed.

Old UI
![image](https://github.com/user-attachments/assets/aac29c9e-2719-4507-a94d-d91c278a0cb3)
![image](https://github.com/user-attachments/assets/a3a3f9b2-59a6-4d52-8ce2-62a9e387a5da)

New UI
![image](https://github.com/user-attachments/assets/5fe9a0d9-e01d-4435-b74e-072b39d56013)


### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [x] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Request review**
      _Tag whomever you wish to review your code_
