### PR TITLE
bug: Add valueChange to description input component

### DIFF
--- a/src/app/modules/data-processing/data-processing-details/data-processing-oversight/data-processing-oversight.component.html
+++ b/src/app/modules/data-processing/data-processing-details/data-processing-oversight/data-processing-oversight.component.html
@@ -37,6 +37,7 @@
         [formGroup]="generalInformationForm"
         formName="remarks"
         data-cy="data-processing-oversight-remarks"
+        (valueChange)="patchOversight({ oversightOptionsRemark: $event })"
         i18n-text
       ></app-textarea>
     </app-standard-vertical-content-grid>


### PR DESCRIPTION
This PR fixes the bug described here (KITOSUDV-5209)[https://os2web.atlassian.net/jira/software/c/projects/KITOSUDV/boards/72?selectedIssue=KITOSUDV-5209]. This fix enables users to input remarks into a dataprocessing oversigt that are then stored in the DB for later reference.

This input field would refresh or be empty whenever you visited the page:
![image](https://github.com/user-attachments/assets/2ac09a6f-d817-42d3-9b0e-ca98054a2727)

Now after inputting some text, that text will reappear once you visit the page again later on.

### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [x] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Request review**
      _Tag whomever you wish to review your code_
