### PR TITLE
[5997] notifications table button behavior and wording

### DIFF
--- a/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.html
+++ b/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.html
@@ -1,6 +1,7 @@
 <app-local-grid
   [data]="(alerts$ | async) ?? []"
   [columns]="gridColumns"
+  deleteIcon="checkmark"
   [deletePermission]="true"
   (deleteEvent)="deleteAlert($event)"
 ></app-local-grid>

--- a/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.ts
+++ b/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
@@ -10,7 +11,6 @@ import { AlertActions } from 'src/app/store/alerts/actions';
 import { selectAlertsByType } from 'src/app/store/alerts/selectors';
 import { Alert, RelatedEntityType } from 'src/app/store/alerts/state';
 import { LocalGridComponent } from '../../../../../shared/components/local-grid/local-grid.component';
-import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'app-alerts-grid',
@@ -42,8 +42,9 @@ export class AlertsGridComponent implements OnInit {
 
   public deleteAlert(alert: Alert): void {
     this.confirmActionService.confirmAction({
-      title: $localize`Slet advarsel`,
-      message: $localize`Er du sikker på, at du vil slette advarslen?`,
+      title: $localize`Fjern notifikation`,
+      message: $localize`Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis?
+      BEMÆRK: dette sletter ikke den pågældende advis.`,
       category: ConfirmActionCategory.Warning,
       onConfirm: () => this.store.dispatch(AlertActions.deleteAlert(this.relatedEntityType, alert.uuid)),
     });

--- a/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.ts
+++ b/src/app/modules/notifications/notification-details/notifications-page/alerts-grid/alerts-grid.component.ts
@@ -43,8 +43,7 @@ export class AlertsGridComponent implements OnInit {
   public deleteAlert(alert: Alert): void {
     this.confirmActionService.confirmAction({
       title: $localize`Fjern notifikation`,
-      message: $localize`Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis?
-      BEMÆRK: dette sletter ikke den pågældende advis.`,
+      message: $localize`Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.`,
       category: ConfirmActionCategory.Warning,
       onConfirm: () => this.store.dispatch(AlertActions.deleteAlert(this.relatedEntityType, alert.uuid)),
     });

--- a/src/app/modules/notifications/notification-details/notifications-page/notifications-page.component.ts
+++ b/src/app/modules/notifications/notification-details/notifications-page/notifications-page.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { SegmentButtonOption } from 'src/app/shared/components/segment/segment.component';
 import { RegistrationEntityTypes } from 'src/app/shared/models/registrations/registration-entity-categories.model';
-import { SegmentComponent } from '../../../../shared/components/segment/segment.component';
 import { CardComponent } from '../../../../shared/components/card/card.component';
+import { SegmentComponent } from '../../../../shared/components/segment/segment.component';
 
-import { NotificationsGridComponent } from './notifications-grid/notifications-grid.component';
 import { AlertsGridComponent } from './alerts-grid/alerts-grid.component';
+import { NotificationsGridComponent } from './notifications-grid/notifications-grid.component';
 
 enum NotificationSegmentType {
   Advis = 'advis',
@@ -31,7 +31,7 @@ export class NotificationsPageComponent {
     },
     {
       value: NotificationSegmentType.Alerts,
-      text: $localize`Ulæste advarsler`,
+      text: $localize`Ikke sendte advis`,
       dataCy: 'alerts-segment',
     },
   ];

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
@@ -17,7 +17,7 @@
         (click)="onDeleteClick()"
         data-cy="grid-delete-button"
         >
-        @if (deleteIcon == 'checkmark') {
+        @if (deleteIcon === 'checkmark') {
           <app-check-icon></app-check-icon>
         }
         @else {

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
@@ -17,7 +17,13 @@
         (click)="onDeleteClick()"
         data-cy="grid-delete-button"
         >
-        <app-trashcan-icon></app-trashcan-icon>
+        @if (deleteIcon == 'trashcan') {
+          <app-trashcan-icon></app-trashcan-icon>
+        }
+        @if (deleteIcon == 'checkmark') {
+          <app-check-icon></app-check-icon>
+        }
+
       </app-icon-button>
     }
     @if (button.type === 'toggle' && (button.visibilityColumn ? getProperty(button.visibilityColumn) : true)) {

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
@@ -17,11 +17,11 @@
         (click)="onDeleteClick()"
         data-cy="grid-delete-button"
         >
-        @if (deleteIcon == 'trashcan') {
-          <app-trashcan-icon></app-trashcan-icon>
-        }
         @if (deleteIcon == 'checkmark') {
           <app-check-icon></app-check-icon>
+        }
+        @else {
+          <app-trashcan-icon></app-trashcan-icon>
         }
       </app-icon-button>
     }

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.html
@@ -23,7 +23,6 @@
         @if (deleteIcon == 'checkmark') {
           <app-check-icon></app-check-icon>
         }
-
       </app-icon-button>
     }
     @if (button.type === 'toggle' && (button.visibilityColumn ? getProperty(button.visibilityColumn) : true)) {

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.ts
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.ts
@@ -1,11 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { BaseCellComponent } from '../../base-cell.component';
-
+import { ActionButtonsCellDeleteIcon } from 'src/app/shared/models/icons/action-buttons-cell-delete-icons';
 import { IconButtonComponent } from '../../../../buttons/icon-button/icon-button.component';
+import { CheckIconComponent } from '../../../../icons/check-icon.component';
 import { PencilIconComponent } from '../../../../icons/pencil-icon.compnent';
 import { TrashcanIconComponent } from '../../../../icons/trashcan-icon.component';
-import { CheckIconComponent } from '../../../../icons/check-icon.component';
 import { ToggleButtonComponent } from '../../../../local-grid/toggle-button/toggle-button.component';
+import { BaseCellComponent } from '../../base-cell.component';
 
 @Component({
   selector: 'app-action-buttons-cell',
@@ -14,7 +14,7 @@ import { ToggleButtonComponent } from '../../../../local-grid/toggle-button/togg
   imports: [IconButtonComponent, PencilIconComponent, TrashcanIconComponent, CheckIconComponent, ToggleButtonComponent],
 })
 export class ActionButtonsCellComponent extends BaseCellComponent {
-  @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
+  @Input() public deleteIcon: ActionButtonsCellDeleteIcon = 'trashcan';
   @Output() public modifyEvent = new EventEmitter<void>();
   @Output() public deleteEvent = new EventEmitter<void>();
   @Output() public toggleEvent = new EventEmitter<boolean>();

--- a/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.ts
+++ b/src/app/shared/components/grid/grid-cell/cell-types/action-buttons-cell/action-buttons-cell.component.ts
@@ -1,18 +1,20 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { BaseCellComponent } from '../../base-cell.component';
 
 import { IconButtonComponent } from '../../../../buttons/icon-button/icon-button.component';
 import { PencilIconComponent } from '../../../../icons/pencil-icon.compnent';
 import { TrashcanIconComponent } from '../../../../icons/trashcan-icon.component';
+import { CheckIconComponent } from '../../../../icons/check-icon.component';
 import { ToggleButtonComponent } from '../../../../local-grid/toggle-button/toggle-button.component';
 
 @Component({
   selector: 'app-action-buttons-cell',
   templateUrl: './action-buttons-cell.component.html',
   styleUrl: './action-buttons-cell.component.scss',
-  imports: [IconButtonComponent, PencilIconComponent, TrashcanIconComponent, ToggleButtonComponent],
+  imports: [IconButtonComponent, PencilIconComponent, TrashcanIconComponent, CheckIconComponent, ToggleButtonComponent],
 })
 export class ActionButtonsCellComponent extends BaseCellComponent {
+  @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
   @Output() public modifyEvent = new EventEmitter<void>();
   @Output() public deleteEvent = new EventEmitter<void>();
   @Output() public toggleEvent = new EventEmitter<boolean>();

--- a/src/app/shared/components/grid/grid-cell/grid-cell.component.html
+++ b/src/app/shared/components/grid/grid-cell/grid-cell.component.html
@@ -105,6 +105,7 @@
     [dataItem]="dataItem"
     [modifyPermission]="modifyPermission"
     [deletePermission]="deletePermission"
+    [deleteIcon]="deleteIcon"
     (toggleEvent)="onToggleEvent($event)"
     (modifyEvent)="onModifyEvent()"
     (deleteEvent)="onDeleteEvent()"

--- a/src/app/shared/components/grid/grid-cell/grid-cell.component.ts
+++ b/src/app/shared/components/grid/grid-cell/grid-cell.component.ts
@@ -1,5 +1,4 @@
-
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { BaseCellComponent } from './base-cell.component';
 import { ActionButtonsCellComponent } from './cell-types/action-buttons-cell/action-buttons-cell.component';
 import { AuditCellComponent } from './cell-types/audit-cell/audit-cell.component';
@@ -42,10 +41,12 @@ import { UuidToNameCellComponent } from './cell-types/uuid-to-name-cell/uuid-to-
     UuidToNameCellComponent,
     AuditCellComponent,
     ActionButtonsCellComponent,
-    ContractStatusChipCellComponent
+    ContractStatusChipCellComponent,
   ],
 })
 export class GridCellComponent extends BaseCellComponent {
+  @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
+
   @Output() public checkboxChange = new EventEmitter<boolean>();
   @Output() public toggleEvent = new EventEmitter<boolean>();
   @Output() public modifyEvent = new EventEmitter<void>();

--- a/src/app/shared/components/grid/grid-cell/grid-cell.component.ts
+++ b/src/app/shared/components/grid/grid-cell/grid-cell.component.ts
@@ -46,7 +46,6 @@ import { UuidToNameCellComponent } from './cell-types/uuid-to-name-cell/uuid-to-
 })
 export class GridCellComponent extends BaseCellComponent {
   @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
-
   @Output() public checkboxChange = new EventEmitter<boolean>();
   @Output() public toggleEvent = new EventEmitter<boolean>();
   @Output() public modifyEvent = new EventEmitter<void>();

--- a/src/app/shared/components/local-grid/local-grid.component.html
+++ b/src/app/shared/components/local-grid/local-grid.component.html
@@ -86,6 +86,7 @@
       <app-grid-cell
         [column]="column"
         [dataItem]="dataItem"
+        [deleteIcon]="deleteIcon"
         (modifyEvent)="onModifyClick(dataItem)"
         (deleteEvent)="onDeleteClick(dataItem)"
         (toggleEvent)="onToggleChange($event, dataItem)"

--- a/src/app/shared/components/local-grid/local-grid.component.ts
+++ b/src/app/shared/components/local-grid/local-grid.component.ts
@@ -36,6 +36,7 @@ import { includedColumnInExport } from '../../helpers/grid-export.helper';
 import { GridColumn } from '../../models/grid-column.model';
 import { GridState, defaultLocalGridState } from '../../models/grid-state.model';
 import { BooleanChange, RowReorderingEvent } from '../../models/grid/grid-events.model';
+import { ActionButtonsCellDeleteIcon } from '../../models/icons/action-buttons-cell-delete-icons';
 import { RegistrationEntityTypes } from '../../models/registrations/registration-entity-categories.model';
 import { GridExportService } from '../../services/grid-export.service';
 import { ChoiceTypeDropdownFilterComponent } from '../grid/choice-type-dropdown-filter/choice-type-dropdown-filter.component';
@@ -96,7 +97,7 @@ export class LocalGridComponent<T> extends BaseComponent implements OnInit {
   @Input() scrollable: 'scrollable' | 'virtual' | 'none' = 'scrollable';
   @Input() resizable: boolean = true;
   @Input() entityType?: RegistrationEntityTypes;
-  @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
+  @Input() public deleteIcon: ActionButtonsCellDeleteIcon = 'trashcan';
 
   @Output() deleteEvent = new EventEmitter<T>();
   @Output() modifyEvent = new EventEmitter<T>();

--- a/src/app/shared/components/local-grid/local-grid.component.ts
+++ b/src/app/shared/components/local-grid/local-grid.component.ts
@@ -96,6 +96,7 @@ export class LocalGridComponent<T> extends BaseComponent implements OnInit {
   @Input() scrollable: 'scrollable' | 'virtual' | 'none' = 'scrollable';
   @Input() resizable: boolean = true;
   @Input() entityType?: RegistrationEntityTypes;
+  @Input() public deleteIcon: 'trashcan' | 'checkmark' = 'trashcan';
 
   @Output() deleteEvent = new EventEmitter<T>();
   @Output() modifyEvent = new EventEmitter<T>();
@@ -111,7 +112,10 @@ export class LocalGridComponent<T> extends BaseComponent implements OnInit {
   public readonly defaultMinimumDateColumnWidth = DEFAULT_DATE_COLUMN_MINIMUM_WIDTH;
   public readonly defaultPrimaryColumnMinimumWidth = DEFAULT_PRIMARY_COLUMN_MINIMUM_WIDTH;
 
-  constructor(private actions$: Actions, private readonly gridExportService: GridExportService) {
+  constructor(
+    private actions$: Actions,
+    private readonly gridExportService: GridExportService,
+  ) {
     super();
     this.allData = this.allData.bind(this);
   }

--- a/src/app/shared/models/icons/action-buttons-cell-delete-icons.ts
+++ b/src/app/shared/models/icons/action-buttons-cell-delete-icons.ts
@@ -1,0 +1,1 @@
+export type ActionButtonsCellDeleteIcon = 'trashcan' | 'checkmark';

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -6211,14 +6211,6 @@
         <source>Ikke angivet</source>
         <target state="new">Ikke angivet</target>
       </trans-unit>
-      <trans-unit id="3349798521063634552" datatype="html">
-        <source>Slet advarsel</source>
-        <target state="new">Slet advarsel</target>
-      </trans-unit>
-      <trans-unit id="250985142269881011" datatype="html">
-        <source>Er du sikker på, at du vil slette advarslen?</source>
-        <target state="new">Er du sikker på, at du vil slette advarslen?</target>
-      </trans-unit>
       <trans-unit id="4279066211673456731" datatype="html">
         <source>Besked</source>
         <target state="new">Besked</target>
@@ -7820,6 +7812,14 @@
       <trans-unit id="3325074221190642573" datatype="html">
         <source>Ikke sendte advis</source>
         <target state="new">Ikke sendte advis</target>
+      </trans-unit>
+      <trans-unit id="3252031869609769068" datatype="html">
+        <source>Fjern notifikation</source>
+        <target state="new">Fjern notifikation</target>
+      </trans-unit>
+      <trans-unit id="3923280420480477937" datatype="html">
+        <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
+        <target state="new">Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -7817,6 +7817,18 @@
         <source>Organisationsenheder med interne betalinger</source>
         <target state="new">Organisationsenheder med interne betalinger</target>
       </trans-unit>
+      <trans-unit id="3252031869609769068" datatype="html">
+        <source>Fjern notifikation</source>
+        <target state="new">Fjern notifikation</target>
+      </trans-unit>
+      <trans-unit id="4634221220301116102" datatype="html">
+        <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
+        <target state="new">Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</target>
+      </trans-unit>
+      <trans-unit id="3325074221190642573" datatype="html">
+        <source>Ikke sendte advis</source>
+        <target state="new">Ikke sendte advis</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -7817,9 +7817,17 @@
         <source>Fjern notifikation</source>
         <target state="new">Fjern notifikation</target>
       </trans-unit>
-      <trans-unit id="3923280420480477937" datatype="html">
+      <trans-unit id="4634221220301116102" datatype="html">
         <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
         <target state="new">Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</target>
+      </trans-unit>
+      <trans-unit id="3585391336506222699" datatype="html">
+        <source>Organisationsenheder med eksterne betalinger</source>
+        <target state="new">Organisationsenheder med eksterne betalinger</target>
+      </trans-unit>
+      <trans-unit id="3132700394017624577" datatype="html">
+        <source>Organisationsenheder med interne betalinger</source>
+        <target state="new">Organisationsenheder med interne betalinger</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -6283,10 +6283,6 @@
         <source>Kommende advis</source>
         <target state="new">Kommende advis</target>
       </trans-unit>
-      <trans-unit id="6454412951656065343" datatype="html">
-        <source>Ulæste advarsler</source>
-        <target state="new">Ulæste advarsler</target>
-      </trans-unit>
       <trans-unit id="7473666767554000615" datatype="html">
         <source>Gå til systemanvendelse</source>
         <target state="new">Gå til systemanvendelse</target>
@@ -7820,6 +7816,10 @@
       <trans-unit id="5253916585354635099" datatype="html">
         <source>Ingen kontrakt</source>
         <target state="new">Ingen kontrakt</target>
+      </trans-unit>
+      <trans-unit id="3325074221190642573" datatype="html">
+        <source>Ikke sendte advis</source>
+        <target state="new">Ikke sendte advis</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -4724,12 +4724,6 @@
       <trans-unit id="6546355986883757646" datatype="html">
         <source>Ikke angivet</source>
       </trans-unit>
-      <trans-unit id="250985142269881011" datatype="html">
-        <source>Er du sikker på, at du vil slette advarslen?</source>
-      </trans-unit>
-      <trans-unit id="3349798521063634552" datatype="html">
-        <source>Slet advarsel</source>
-      </trans-unit>
       <trans-unit id="4279066211673456731" datatype="html">
         <source>Besked</source>
       </trans-unit>
@@ -5986,6 +5980,12 @@
       </trans-unit>
       <trans-unit id="3325074221190642573" datatype="html">
         <source>Ikke sendte advis</source>
+      </trans-unit>
+      <trans-unit id="3252031869609769068" datatype="html">
+        <source>Fjern notifikation</source>
+      </trans-unit>
+      <trans-unit id="3923280420480477937" datatype="html">
+        <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -5984,6 +5984,15 @@
       <trans-unit id="3585391336506222699" datatype="html">
         <source>Organisationsenheder med eksterne betalinger</source>
       </trans-unit>
+      <trans-unit id="3252031869609769068" datatype="html">
+        <source>Fjern notifikation</source>
+      </trans-unit>
+      <trans-unit id="3325074221190642573" datatype="html">
+        <source>Ikke sendte advis</source>
+      </trans-unit>
+      <trans-unit id="4634221220301116102" datatype="html">
+        <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -5984,8 +5984,14 @@
       <trans-unit id="3252031869609769068" datatype="html">
         <source>Fjern notifikation</source>
       </trans-unit>
-      <trans-unit id="3923280420480477937" datatype="html">
+      <trans-unit id="4634221220301116102" datatype="html">
         <source>Er du sikker på, at du vil fjerne notifikationen om manglende afsendelse af advis? BEMÆRK: dette sletter ikke den pågældende advis.</source>
+      </trans-unit>
+      <trans-unit id="3132700394017624577" datatype="html">
+        <source>Organisationsenheder med interne betalinger</source>
+      </trans-unit>
+      <trans-unit id="3585391336506222699" datatype="html">
+        <source>Organisationsenheder med eksterne betalinger</source>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -4775,9 +4775,6 @@
       <trans-unit id="4766365470163586672" datatype="html">
         <source>Den markerede kontrakt er inaktiv</source>
       </trans-unit>
-      <trans-unit id="6454412951656065343" datatype="html">
-        <source>Ulæste advarsler</source>
-      </trans-unit>
       <trans-unit id="7018355465405167274" datatype="html">
         <source>Kommende advis</source>
       </trans-unit>
@@ -5986,6 +5983,9 @@
       </trans-unit>
       <trans-unit id="5253916585354635099" datatype="html">
         <source>Ingen kontrakt</source>
+      </trans-unit>
+      <trans-unit id="3325074221190642573" datatype="html">
+        <source>Ikke sendte advis</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
This improves the user experience of the table with notifications about advis that have not been sent due to some error. It does so by clarifying the texts shown to users and using a checkmark icon instead of a trashcan for removing the notifications. The previous icon made users think they were deleting the "underlying" advis itself.

### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [x] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Request review**
      _Tag whomever you wish to review your code_
