### PR TITLE
Retain disableByDefault state of nodes first time putting

### DIFF
--- a/src/app/modules/local-admin/ui-config/ui-config-tab-section/ui-config-tab-section.component.ts
+++ b/src/app/modules/local-admin/ui-config/ui-config-tab-section/ui-config-tab-section.component.ts
@@ -1,20 +1,20 @@
-import { Store } from '@ngrx/store';
-import { UIModuleConfigKey } from 'src/app/shared/enums/ui-module-config-key';
+import { AsyncPipe } from '@angular/common';
 import { Component, Input } from '@angular/core';
+import { Store } from '@ngrx/store';
 import { map, Observable } from 'rxjs';
+import { APICustomizedUINodeResponseDTO } from 'src/app/api/v2';
+import { UIModuleConfigKey } from 'src/app/shared/enums/ui-module-config-key';
 import { UIConfigNodeViewModel } from 'src/app/shared/models/ui-config/ui-config-node-view-model.model';
 import { UINodeCustomization } from 'src/app/shared/models/ui-config/ui-node-customization';
 import { UIModuleConfigActions } from 'src/app/store/organization/ui-module-customization/actions';
 import { selectUIConfigLoading } from 'src/app/store/organization/ui-module-customization/selectors';
 import { AccordionComponent } from '../../../../shared/components/accordion/accordion.component';
+import { CheckboxButtonComponent } from '../../../../shared/components/buttons/checkbox-button/checkbox-button.component';
 import { DividerComponent } from '../../../../shared/components/divider/divider.component';
-import { AsyncPipe } from '@angular/common';
+import { InfoIconComponent } from '../../../../shared/components/icons/info-icon.component';
 import { ParagraphComponent } from '../../../../shared/components/paragraph/paragraph.component';
 import { StandardVerticalContentGridComponent } from '../../../../shared/components/standard-vertical-content-grid/standard-vertical-content-grid.component';
-import { CheckboxButtonComponent } from '../../../../shared/components/buttons/checkbox-button/checkbox-button.component';
 import { TooltipComponent } from '../../../../shared/components/tooltip/tooltip.component';
-import { InfoIconComponent } from '../../../../shared/components/icons/info-icon.component';
-import { APICustomizedUINodeResponseDTO } from 'src/app/api/v2';
 
 @Component({
   selector: 'app-ui-config-tab-section',
@@ -28,8 +28,8 @@ import { APICustomizedUINodeResponseDTO } from 'src/app/api/v2';
     CheckboxButtonComponent,
     TooltipComponent,
     InfoIconComponent,
-    AsyncPipe
-],
+    AsyncPipe,
+  ],
 })
 export class UiConfigTabSectionComponent {
   @Input() tabViewModel!: UIConfigNodeViewModel;

--- a/src/app/shared/models/ui-config/SimpleUINodeBlueprint.ts
+++ b/src/app/shared/models/ui-config/SimpleUINodeBlueprint.ts
@@ -1,0 +1,4 @@
+export interface SimpleUINodeBlueprint {
+  fullKey?: string;
+  disableByDefault?: boolean;
+}

--- a/src/app/shared/services/ui-config-services/ui-config.service.ts
+++ b/src/app/shared/services/ui-config-services/ui-config.service.ts
@@ -4,6 +4,7 @@ import { DataProcessingUiBluePrint } from '../../models/ui-config/blueprints/dat
 import { GdprUiBluePrint } from '../../models/ui-config/blueprints/gdpr-blueprint';
 import { ItContractsUiBluePrint } from '../../models/ui-config/blueprints/it-contracts-blueprint';
 import { ItSystemUsageUiBluePrint } from '../../models/ui-config/blueprints/it-system-usages-blueprint';
+import { SimpleUINodeBlueprint } from '../../models/ui-config/SimpleUINodeBlueprint';
 import { UIConfigNodeViewModel } from '../../models/ui-config/ui-config-node-view-model.model';
 import { UIModuleConfig } from '../../models/ui-config/ui-module-config.model';
 import { UINodeBlueprint } from '../../models/ui-config/ui-node-blueprint.model';
@@ -22,9 +23,12 @@ export class UIConfigService {
     return { module, moduleConfigViewModel, cacheTime: undefined };
   }
 
-  public getAllNodesOfBlueprint(moduleKey: UIModuleConfigKey): UINodeBlueprint[] {
+  public getAllNodesOfBlueprint(moduleKey: UIModuleConfigKey): SimpleUINodeBlueprint[] {
     const blueprint = this.getUIBlueprintWithFullKeys(moduleKey);
-    return this.flattenUINodeBlueprint(blueprint);
+    return this.flattenUINodeBlueprint(blueprint).map((node) => ({
+      fullKey: node.fullKey,
+      disableByDefault: node.disableByDefault,
+    }));
   }
 
   private findCustomizedUINode(customizationList: UINodeCustomization[], fullKey: string): UINodeCustomization | null {

--- a/src/app/shared/services/ui-config-services/ui-config.service.ts
+++ b/src/app/shared/services/ui-config-services/ui-config.service.ts
@@ -22,9 +22,9 @@ export class UIConfigService {
     return { module, moduleConfigViewModel, cacheTime: undefined };
   }
 
-  public getAllKeysOfBlueprint(moduleKey: UIModuleConfigKey): string[] {
+  public getAllNodesOfBlueprint(moduleKey: UIModuleConfigKey): UINodeBlueprint[] {
     const blueprint = this.getUIBlueprintWithFullKeys(moduleKey);
-    return this.flattenUINodeBlueprintKeys(blueprint);
+    return this.flattenUINodeBlueprint(blueprint);
   }
 
   private findCustomizedUINode(customizationList: UINodeCustomization[], fullKey: string): UINodeCustomization | null {
@@ -123,19 +123,17 @@ export class UIConfigService {
     return (key.match(/\./g) || []).length;
   }
 
-  private flattenUINodeBlueprintKeys(root: UINodeBlueprint): string[] {
-    let result: string[] = [];
+  private flattenUINodeBlueprint(root: UINodeBlueprint): UINodeBlueprint[] {
+    let result: UINodeBlueprint[] = [];
 
-    // If the current node has a fullKey, add it to the list.
     if (root.fullKey !== undefined) {
-      result.push(root.fullKey);
+      result.push(root);
     }
 
-    // If there are children, recursively flatten them and merge into the result.
     if (root.children) {
       for (const key in root.children) {
         const child = root.children[key];
-        result = result.concat(this.flattenUINodeBlueprintKeys(child));
+        result = result.concat(this.flattenUINodeBlueprint(child));
       }
     }
 

--- a/src/app/store/organization/ui-module-customization/effects.ts
+++ b/src/app/store/organization/ui-module-customization/effects.ts
@@ -208,10 +208,10 @@ export class UIModuleCustomizationEffects {
     response: APICustomizedUINodeResponseDTO[],
     module: UIModuleConfigKey,
   ): APICustomizedUINodeResponseDTO[] {
-    const allKeys = this.uiConfigService.getAllKeysOfBlueprint(module);
+    const allNodes = this.uiConfigService.getAllNodesOfBlueprint(module);
     const existingKeys = new Set(response.map((node) => node.key));
-    const missingKeys = allKeys.filter((key) => !existingKeys.has(key));
-    const nodesToAdd = missingKeys.map((key) => ({ key, enabled: true }));
+    const missingKeys = allNodes.filter((node) => node.fullKey !== undefined && !existingKeys.has(node.fullKey));
+    const nodesToAdd = missingKeys.map((node) => ({ key: node.fullKey!, enabled: !node.disableByDefault }));
     return [...response, ...nodesToAdd];
   }
 }

--- a/src/app/store/organization/ui-module-customization/effects.ts
+++ b/src/app/store/organization/ui-module-customization/effects.ts
@@ -210,8 +210,8 @@ export class UIModuleCustomizationEffects {
   ): APICustomizedUINodeResponseDTO[] {
     const allNodes = this.uiConfigService.getAllNodesOfBlueprint(module);
     const existingKeys = new Set(response.map((node) => node.key));
-    const missingKeys = allNodes.filter((node) => node.fullKey !== undefined && !existingKeys.has(node.fullKey));
-    const nodesToAdd = missingKeys.map((node) => ({ key: node.fullKey!, enabled: !node.disableByDefault }));
+    const missingNodes = allNodes.filter((node) => node.fullKey !== undefined && !existingKeys.has(node.fullKey));
+    const nodesToAdd = missingNodes.map((node) => ({ key: node.fullKey!, enabled: !node.disableByDefault }));
     return [...response, ...nodesToAdd];
   }
 }


### PR DESCRIPTION
### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

#### Description
The "disableByDefault" flag on UI customization blueprint nodes was not being respected when a new organization PUT its customization the first time. 

To test, make a fresh database and try to toggle on/off any field in eg. the It System Usage Customization. This should only toggle the clicked field, whereas it used to incorrectly turn on all fields that are disabledByDefault.

#### Checklist
- [ ] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [ ] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [ ] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [ ] **Test the pull request**
      _Test all of the changes made_
- [ ] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [ ] **Self-review**
      _Before requesting a review do a yet another self-review_
- [ ] **Add a description**
      _Under "Description" above, explain what was changed in this branch, and WHY it was changed_
- [ ] **Request review**
      _Tag whomever you wish to review your code_
