### PR TITLE
 [6172] preserve org user columns in session

### DIFF
--- a/src/app/modules/organization/organization-users/organization-users.component.ts
+++ b/src/app/modules/organization/organization-users/organization-users.component.ts
@@ -217,14 +217,15 @@ export class OrganizationUsersComponent extends BaseOverviewComponent implements
 
   ngOnInit(): void {
     this.store.dispatch(OrganizationUserActions.getOrganizationUserPermissions());
+    const orderedDefaultColumns = this.mapColumnOrder(this.defaultGridColumns);
     const existingColumns = this.gridColumnStorageService.getColumns(
       ORGANIZATION_USER_COLUMNS_ID,
-      this.defaultGridColumns,
+      orderedDefaultColumns,
     );
     if (existingColumns) {
       this.store.dispatch(OrganizationUserActions.updateGridColumns(existingColumns));
     } else {
-      this.updateDefaultColumns();
+      this.store.dispatch(OrganizationUserActions.updateGridColumns(orderedDefaultColumns));
     }
 
     this.gridState$.pipe(first()).subscribe((gridState) => this.stateChange(gridState));
@@ -263,6 +264,7 @@ export class OrganizationUsersComponent extends BaseOverviewComponent implements
     this.subscriptions.add(
       this.isGlobalAdmin$.pipe(first()).subscribe((isGlobalAdmin) => {
         this.dialogOpenerService.openEditUserDialog(user, false, isGlobalAdmin);
+      }),
       }),
     );
   }

--- a/src/app/modules/organization/organization-users/organization-users.component.ts
+++ b/src/app/modules/organization/organization-users/organization-users.component.ts
@@ -265,7 +265,6 @@ export class OrganizationUsersComponent extends BaseOverviewComponent implements
       this.isGlobalAdmin$.pipe(first()).subscribe((isGlobalAdmin) => {
         this.dialogOpenerService.openEditUserDialog(user, false, isGlobalAdmin);
       }),
-      }),
     );
   }
 

--- a/src/app/shared/services/grid-column-storage-service.ts
+++ b/src/app/shared/services/grid-column-storage-service.ts
@@ -23,7 +23,7 @@ export class GridColumnStorageService {
   }
 
   private computeHash(columns: GridColumn[]): string {
-    const hashableColumns = columns.map(this.toHashableGridColumn).sort((a, b) => a.field.localeCompare(b.field));
+    const hashableColumns = columns.map(this.ignoreUserCustomizableColumnProperties).sort((a, b) => a.field.localeCompare(b.field));
     return this.hashMappedColumns(hashableColumns);
   }
 
@@ -47,7 +47,7 @@ export class GridColumnStorageService {
 
   // Marks the fields that are not relevant for hashing, to a constant, as to not effect the hash.
   // Needs to be extended if more fields are added to the GridColumn, which shouldn't be hashed
-  private toHashableGridColumn(column: GridColumn): GridColumn {
+  private ignoreUserCustomizableColumnProperties(column: GridColumn): GridColumn {
     return { ...column, width: undefined, hidden: false, disabledByUIConfig: undefined };
   }
 }

--- a/src/app/shared/services/grid-column-storage-service.ts
+++ b/src/app/shared/services/grid-column-storage-service.ts
@@ -18,12 +18,17 @@ export class GridColumnStorageService {
     const cachedColumns = existingCache?.columns;
     if (!cachedColumns) return null;
     const newHash = this.computeHash(defaultColumns);
-    if (existingCache.hash !== newHash) return null;
-    return cachedColumns;
+    return this.columnDefinitionsHaveChanged(existingCache.hash, newHash) ? null : cachedColumns;
+  }
+
+  private columnDefinitionsHaveChanged(existingHash: string, newHash: string) {
+    return existingHash !== newHash;
   }
 
   private computeHash(columns: GridColumn[]): string {
-    const hashableColumns = columns.map(this.ignoreUserCustomizableColumnProperties).sort((a, b) => a.field.localeCompare(b.field));
+    const hashableColumns = columns
+      .map(this.ignoreUserCustomizableColumnProperties)
+      .sort((a, b) => a.field.localeCompare(b.field));
     return this.hashMappedColumns(hashableColumns);
   }
 

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -7913,6 +7913,10 @@
         <source> Prøv manuel login ved fejl </source>
         <target state="new"> Prøv manuel login ved fejl </target>
       </trans-unit>
+      <trans-unit id="8384286620027712249" datatype="html">
+        <source>Teknisk systemtyper</source>
+        <target state="new">Teknisk systemtyper</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
### PR requirements

Follow this guide to test and review: https://strongminds.atlassian.net/wiki/spaces/KITOS/pages/993984514/QA

#### Description
Like in other overviews, the column setup for the Users grid is now preserved across reloads.

#### Checklist
- [x] **Validate UI wrt Figma wireframe**
      _Look through the Figma [wireframe](https://www.figma.com/design/R1LSxTympqqC1XUCNaj6EF/Kitos-%2F-design-system-%26-redesign?node-id=531-74700&m=dev) with similar elements and validate the implementation_
- [x] **Remember to check for missing translations**
      _Did you remember to run `yarn i18n`_?
- [x] **Merge current master in your local branch**
      _Make sure you are testing your changes and how they co-exist with the latest version of master_
- [x] **Test the pull request**
      _Test all of the changes made_
- [x] **Verify that Cypress tests are all green**
      _This is part of the PR checks, so look at the PR page itself_
- [x] **Self-review**
      _Before requesting a review do a yet another self-review_
- [x] **Add a description**
      _Under "Description" above, explain what was changed in this branch, and WHY it was changed_
- [x] **Request review**
      _Tag whomever you wish to review your code_
